### PR TITLE
Fix throw missing file error

### DIFF
--- a/src/AppleSafariPinGenerator.php
+++ b/src/AppleSafariPinGenerator.php
@@ -68,7 +68,9 @@ final class AppleSafariPinGenerator implements GeneratorInterface
             return $callback($tempSource, $tempTarget);
         } finally {
             \unlink($tempSource);
-            @\unlink($tempTarget);
+            if (\is_file($tempTarget) {
+                \unlink($tempTarget);
+            }
         }
     }
 

--- a/src/AppleSafariPinGenerator.php
+++ b/src/AppleSafariPinGenerator.php
@@ -68,7 +68,7 @@ final class AppleSafariPinGenerator implements GeneratorInterface
             return $callback($tempSource, $tempTarget);
         } finally {
             \unlink($tempSource);
-            \unlink($tempTarget);
+            @\unlink($tempTarget);
         }
     }
 


### PR DESCRIPTION
When the conversion fails, it throws an error message about that. However, it is getting interrupted when the target file is missing when attempting to delete it. This makes sure the intended error is surfaced.